### PR TITLE
fix: tests were missing cargo home

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
 
     - name: Run tests
       id: tests
+      env:
+        CARGO_HOME: ${{ github.workspace }}/.cargo
       run: |
         echo "Running tests using 'make test'..."
 


### PR DESCRIPTION
## Description
The testing step of the release workflow was failing due to not adjusting `CARGO_HOME`.
